### PR TITLE
Two typography bugfixes

### DIFF
--- a/checkwriting
+++ b/checkwriting
@@ -237,6 +237,7 @@ sub fixTypography{
   #http://www.ece.ucdavis.edu/~jowens/commonerrors.html
   $c += ($str =~ s/\b((?:et\sal\.|i\.e\.) )/\x{EFFF}$typography_color$1<slash escape the space>$def_color\x{EFFF}/og);
   $c += ($str =~ s/([^\s]*[A-Z]\.)/\x{EFFF}$typography_color$1<add a \\\@>$def_color\x{EFFF}/og);
+  $c += ($str =~ s/\b(,\set\sal\.)/\x{EFFF}$typography_color$1<no comma before et al.>$def_color\x{EFFF}/og);
   $c += ($str =~ s/(\s\d{4,}\b)/\x{EFFF}$typography_color$1$def_color\x{EFFF}/go) if $options{'number'};
   #URLs should be typeset with \url
   $c += fixURL();

--- a/test
+++ b/test
@@ -2,6 +2,7 @@ this is an example test file for the
 the academic writing scripts. It is hoped that
 all these lines shall be clearly printed.
 i.e et al.
+Dev, et al.\ should not have a comma.
 http://www.google.com/
 \url{http://not.this.com}
 3443 marked


### PR DESCRIPTION
(1) Prior version only caught missing \@ glyphs for single-character ACRONYMS.

"This sentence ends in an ACRYONYM. It needs a slash-at."

(2) There shouldn't be a comma in "Name, et al.". Detect this.

"Dev, et al.\ shouldn't have a comma."

Also added test cases for both.
